### PR TITLE
🧹 fallback to home directory if lastSavedPluginDir is undefined

### DIFF
--- a/src/main/ExtensionManager.ts
+++ b/src/main/ExtensionManager.ts
@@ -589,10 +589,10 @@ export default class ExtensionManager {
       title: data.dir.name
         ? "Choose plugin directory location"
         : "Choose plugin name and directory location",
-      // TODO: if lastSavedPluginDir is undefined, use home dir
-      defaultPath: storage.settings.app.lastSavedPluginDir
-        ? resolve(storage.settings.app.lastSavedPluginDir, data.dir.name)
-        : data.dir.name,
+      defaultPath: resolve(
+        storage.settings.app.lastSavedPluginDir || app.getPath("home"),
+        data.dir.name || "",
+      ),
     });
 
     if (!path) {


### PR DESCRIPTION
This change improves the user experience when adding a new plugin by providing a sensible default directory (the user's home directory) if no plugin has been saved before. It addresses a TODO in the codebase.

Changes:
- In `src/main/ExtensionManager.ts`, updated the `writeNewExtensionDirectoryToDisk` method to use `app.getPath("home")` as a fallback for `defaultPath` in the save dialog.
- Ensured that unrelated formatting changes were reverted to maintain a clean PR.
- Verified the logic and ensured no new issues were introduced.

---
*PR created automatically by Jules for task [10520699915299984851](https://jules.google.com/task/10520699915299984851) started by @arximus88*