### PR TITLE
🧪 [testing improvement] Add comprehensive tests for normalizeUrl

### DIFF
--- a/src/utils/Common/url.test.ts
+++ b/src/utils/Common/url.test.ts
@@ -1,0 +1,26 @@
+import { describe, test, expect } from "bun:test";
+import { normalizeUrl } from "./url";
+import { HOMEPAGE } from "Const";
+
+describe("normalizeUrl", () => {
+  test("replaces figma:// protocol with HOMEPAGE", () => {
+    expect(normalizeUrl("figma://file/123")).toBe(`${HOMEPAGE}/file/123`);
+  });
+
+  test("does not modify standard https URLs", () => {
+    expect(normalizeUrl("https://www.figma.com/file/123")).toBe("https://www.figma.com/file/123");
+  });
+
+  test("does not modify other protocols", () => {
+    expect(normalizeUrl("http://localhost:3000")).toBe("http://localhost:3000");
+    expect(normalizeUrl("ftp://example.com")).toBe("ftp://example.com");
+  });
+
+  test("does not modify empty string", () => {
+    expect(normalizeUrl("")).toBe("");
+  });
+
+  test("does not modify URLs starting with figma: but without //", () => {
+    expect(normalizeUrl("figma:file")).toBe("figma:file");
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Added tests for `normalizeUrl` function in `src/utils/Common/url.ts` which previously lacked tests.

📊 **Coverage:** What scenarios are now tested
- Replaces `figma://` protocol with `HOMEPAGE` url correctly
- Does not modify standard `https://` URLs
- Does not modify other protocols like `http://` or `ftp://`
- Does not modify empty string input
- Does not modify URLs starting with `figma:` but without `//`

✨ **Result:** The improvement in test coverage
`normalizeUrl` has a robust test suite covering happy paths and edge cases, acting as a safety net against regressions. All tests are deterministic and rely on Bun's test runner, requiring no external mocked states.

---
*PR created automatically by Jules for task [14189612650609737358](https://jules.google.com/task/14189612650609737358) started by @arximus88*