### PR TITLE
🧪 Add tests and fix regex for isFigmaValidUrl

### DIFF
--- a/src/utils/Main/url.test.ts
+++ b/src/utils/Main/url.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { isFigmaValidUrl } from "./url";
+
+describe("url utils", () => {
+  describe("isFigmaValidUrl", () => {
+    test("should return true for valid Figma desktop app urls", () => {
+      expect(isFigmaValidUrl("figma://file/abc")).toBe(true);
+      expect(isFigmaValidUrl("figma://")).toBe(true);
+    });
+
+    test("should return true for valid Figma web urls", () => {
+      expect(isFigmaValidUrl("https://figma.com/file/abc")).toBe(true);
+      expect(isFigmaValidUrl("http://figma.com/file/abc")).toBe(true);
+      expect(isFigmaValidUrl("https://www.figma.com/file/abc")).toBe(true);
+      expect(isFigmaValidUrl("http://www.figma.com/file/abc")).toBe(true);
+      expect(isFigmaValidUrl("https://w.figma.com/file/abc")).toBe(true);
+      expect(isFigmaValidUrl("https://ww.figma.com/file/abc")).toBe(true);
+    });
+
+    test("should return false for invalid urls", () => {
+      expect(isFigmaValidUrl("ftp://figma.com")).toBe(false);
+      expect(isFigmaValidUrl("https://notfigma.com")).toBe(false);
+      expect(isFigmaValidUrl("http://google.com")).toBe(false);
+      expect(isFigmaValidUrl("figma.com")).toBe(false);
+      expect(isFigmaValidUrl("file://figma.com")).toBe(false);
+      expect(isFigmaValidUrl("https://wwwfigma.com")).toBe(false);
+      expect(isFigmaValidUrl("https://wfigma.com")).toBe(false);
+    });
+  });
+});

--- a/src/utils/Main/url.ts
+++ b/src/utils/Main/url.ts
@@ -26,5 +26,5 @@ export const bridgePreloadPathDev = `${resolve(__dirname, "../renderer", "bridge
 export const bridgePreloadPathProd = `${resolve(__dirname, "../renderer", "bridge.js")}`;
 
 export const isFigmaValidUrl = (url: string): boolean => {
-  return /^(figma:\/\/|https?:\/\/w{0,3}?\.?figma\.com)/.test(url);
+  return /^(figma:\/\/|https?:\/\/(w{0,3}\.)?figma\.com)/.test(url);
 };


### PR DESCRIPTION
🎯 **What:** The `isFigmaValidUrl` function was missing tests, leading to an undetected regex bug where domains like `wwwfigma.com` were accepted as valid.
📊 **Coverage:** Added a test file `src/utils/Main/url.test.ts` to cover valid desktop app URLs, valid web URLs, and invalid URLs (e.g., other protocols, bad domains).
✨ **Result:** Enhanced test coverage ensures future modifications to URL validation won't break existing behavior. Discovered and fixed a bug by updating `w{0,3}?\.?` to `(w{0,3}\.)?`. All tests run successfully via `bun test` alongside the rest of the project's suite.

---
*PR created automatically by Jules for task [11101851466430405180](https://jules.google.com/task/11101851466430405180) started by @arximus88*