### PR TITLE
🧪 add tests for wait utility

### DIFF
--- a/src/utils/Common/wait.test.ts
+++ b/src/utils/Common/wait.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test, spyOn } from "bun:test";
+import { wait } from "./wait";
+
+describe("wait utility", () => {
+  test("should resolve after at least the specified duration", async () => {
+    const ms = 50;
+    const start = Date.now();
+    await wait(ms);
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeGreaterThanOrEqual(ms);
+  });
+
+  test("should call setTimeout with the correct duration", async () => {
+    const ms = 100;
+    const spy = spyOn(globalThis, "setTimeout");
+
+    const waitPromise = wait(ms);
+
+    expect(spy).toHaveBeenCalled();
+    expect(spy.mock.calls[0][1]).toBe(ms);
+
+    await waitPromise;
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
This change adds unit tests for the `wait` utility function. The tests use `bun:test` and include checks for both the behavior (waiting at least the specified duration) and the implementation (correct `setTimeout` call).

---
*PR created automatically by Jules for task [17418682449310806909](https://jules.google.com/task/17418682449310806909) started by @arximus88*