### PR TITLE
fix: restore valid import order in Panel components

### DIFF
--- a/src/renderer/Panel/Components/Left.svelte
+++ b/src/renderer/Panel/Components/Left.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-    import { ButtonWindow, ButtonTool } from "Common/Buttons";
-import { getContext } from "svelte";
+  import { getContext } from "svelte";
   import type { FrameTheme } from "Utils/Render/frameTheme";
-  const theme = getContext<FrameTheme>("frameTheme");
-  const config = $derived(theme.config);
+  import { ButtonWindow, ButtonTool } from "Common/Buttons";
   import { newFileVisible, communityTabVisible, currentTab } from "../store";
   import { onClickHome, onClickNewProject, onClickCommunity } from "./utils";
 
-  </script>
+  const theme = getContext<FrameTheme>("frameTheme");
+  const config = $derived(theme.config);
+</script>
 
 <div class="panel-left">
   <ButtonWindow

--- a/src/renderer/Panel/Components/Right.svelte
+++ b/src/renderer/Panel/Components/Right.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-    import { ButtonWindow } from "Common/Buttons";
-import { getContext } from "svelte";
+  import { getContext } from "svelte";
   import type { FrameTheme } from "Utils/Render/frameTheme";
+  import { ButtonWindow } from "Common/Buttons";
+  import { tabs, isMenuOpen } from "../store";
+
   const theme = getContext<FrameTheme>("frameTheme");
   const config = $derived(theme.config);
-  import { tabs, isMenuOpen } from "../store";
 
 
   function clickMenu() {

--- a/src/renderer/Panel/Components/Tabs.svelte
+++ b/src/renderer/Panel/Components/Tabs.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
-    import { tabs, currentTab } from "../store";
-import { getContext } from "svelte";
+  import { getContext } from "svelte";
   import type { FrameTheme } from "Utils/Render/frameTheme";
-  const theme = getContext<FrameTheme>("frameTheme");
-  const config = $derived(theme.config);
+  import { tabs, currentTab } from "../store";
   import { closeTab, tabFocus } from "./utils";
   import List from "./List.svelte";
   import { NEW_FILE_TAB_TITLE } from "../../../constants/other";
+
+  const theme = getContext<FrameTheme>("frameTheme");
+  const config = $derived(theme.config);
 
 
   let currentTabId = $state<number | undefined>();


### PR DESCRIPTION
The frameTheme refactor patch produced malformed script blocks where `import` statements appeared after executable code (getContext call and $derived assignment). ES modules require all imports to appear before any executable statements, and Svelte enforces this as well.

Moves all imports to the top of each <script> block in Left.svelte, Tabs.svelte, and Right.svelte so the components compile and render correctly.