### PR TITLE
chore: remove setAutosize no-ops and fix post-migration type casts

### DIFF
--- a/src/main/App.ts
+++ b/src/main/App.ts
@@ -27,7 +27,6 @@ export default class App {
 
   constructor(
     private windowManager: WindowManager,
-    private extensionManager: ExtensionManager,
     private session: Session,
     private fontManager: FontManager,
   ) {
@@ -210,7 +209,6 @@ export default class App {
       logger.info("Wayland session detected - enabling native Wayland support");
       app.commandLine.appendSwitch("ozone-platform-hint", "auto");
       features.push("WaylandWindowDecorations", "UseOzonePlatform");
-
     }
 
     // Enable modern rendering features
@@ -222,7 +220,9 @@ export default class App {
     // User can still force it via commandSwitches if they know what they're doing.
     if (!isWayland || userForcesVulkan) {
       if (userForcesVulkan && isWayland) {
-        logger.warn("enable-unsafe-webgpu forced on Wayland via commandSwitches — Vulkan may conflict with the compositor");
+        logger.warn(
+          "enable-unsafe-webgpu forced on Wayland via commandSwitches — Vulkan may conflict with the compositor",
+        );
       }
       app.commandLine.appendSwitch("enable-unsafe-webgpu");
     }

--- a/src/main/Ui/CommunityTab.ts
+++ b/src/main/Ui/CommunityTab.ts
@@ -38,16 +38,6 @@ export default class CommunityTab {
   public getUrl() {
     return this.view.webContents.getURL();
   }
-  public setAutosize(flag: boolean) {
-    /*
-    this.view.setAutoResize({
-      width: false,
-      height: false,
-      horizontal: false,
-      vertical: false,
-    });
-    */
-  }
   public setBounds(bounds: Rectangle) {
     this.view.setBounds(bounds);
   }
@@ -61,10 +51,8 @@ export default class CommunityTab {
         zoomFactor: 1,
         preload: isDev ? preloadScriptPathDev : preloadScriptPathProd,
       },
-    } as any);
+    });
     this.id = this.view.webContents.id;
-
-    this.setAutosize(false);
 
     isDev && toggleDetachedDevTools(this.view.webContents);
 

--- a/src/main/Ui/MainTab.ts
+++ b/src/main/Ui/MainTab.ts
@@ -74,16 +74,6 @@ export default class MainTab {
   public handleUrl(path: string) {
     this.view.webContents.send("handleUrl", path);
   }
-  public setAutosize(flag: boolean) {
-    /*
-    this.view.setAutoResize({
-      width: false,
-      height: false,
-      horizontal: false,
-      vertical: false,
-    });
-    */
-  }
   public setBounds(bounds: Rectangle) {
     this.view.setBounds(bounds);
   }
@@ -92,11 +82,10 @@ export default class MainTab {
     this._userId = storage.settings.userId;
     const url = `${RECENT_FILES}/?fuid=${this._userId}`;
 
-    this.view = new WebContentsView(this.options as any);
+    this.view = new WebContentsView(this.options);
     this.id = this.view.webContents.id;
 
     this.loadUrl(url);
-    this.setAutosize(false);
 
     isDev && toggleDetachedDevTools(this.view.webContents);
 

--- a/src/main/Ui/SettingsView.ts
+++ b/src/main/Ui/SettingsView.ts
@@ -20,17 +20,8 @@ export default class SettingsView {
         experimentalFeatures: false,
         webviewTag: true,
       },
-    } as any);
-    this.view.setBackgroundColor("#00000000");
-
-    /*
-    this.view.setAutoResize({
-      width: false,
-      height: false,
-      horizontal: false,
-      vertical: false,
     });
-    */
+    this.view.setBackgroundColor("#00000000");
 
     this.view.webContents.loadURL(isDev ? settingsUrlDev : settingsUrlProd);
 

--- a/src/main/Ui/Tab.ts
+++ b/src/main/Ui/Tab.ts
@@ -46,9 +46,7 @@ export default class Tab {
   public getUrl() {
     return this.view.webContents.getURL();
   }
-  public setAutosize(flag: boolean) {
-    // WebContentsView does not support setAutoResize
-  }
+
   public setBounds(bounds: Rectangle) {
     this.view.setBounds(bounds);
   }
@@ -62,7 +60,7 @@ export default class Tab {
         zoomFactor: 1,
         preload: isDev ? preloadScriptPathDev : preloadScriptPathProd,
       },
-    } as any);
+    });
     this.id = this.view.webContents.id;
 
     app.emit("requestBoundsForTabView", this.windowId);

--- a/src/main/Ui/Window.ts
+++ b/src/main/Ui/Window.ts
@@ -564,13 +564,13 @@ export default class Window {
     return this.tabManager.lastFocusedTab;
   }
 
-  /** Execute arbitrary JS from within the active Figma BrowserView context. */
+  /** Execute arbitrary JS from within the active Figma WebContentsView context. */
   public executeInBrowserView(script: string): Promise<any> {
     const tab = this.tabManager.getById(this.tabManager.lastFocusedTab);
     return tab.view.webContents.executeJavaScript(script);
   }
 
-  /** Execute a fetch from within the active Figma BrowserView context.
+  /** Execute a fetch from within the active Figma WebContentsView context.
    *  Uses relative paths on www.figma.com so session cookies are sent automatically.
    *  @param path - relative path, e.g. "/api/files/{key}/nodes?ids=..." */
   public figmaApiFetch(path: string): Promise<any> {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -29,7 +29,7 @@ async function start() {
   const extensionManager = new ExtensionManager();
   const windowManager = new WindowManager();
 
-  new App(windowManager, extensionManager, session, fontManager);
+  new App(windowManager, session, fontManager);
 }
 
 start();


### PR DESCRIPTION
- **Tab.ts, MainTab.ts, CommunityTab.ts**: Removed empty `setAutosize` method definitions and `this.setAutosize(false)` call sites from `initTab()`.
- **Tab.ts, MainTab.ts, CommunityTab.ts, SettingsView.ts**: Removed `as any` type casting when constructing `WebContentsView` since Electron types are up-to-date. Also removed commented-out `setAutoResize` usage in `SettingsView.ts`.
- **App.ts, index.ts**: Removed unused `extensionManager` dependency injection from `App.ts` constructor and instantiation in `index.ts`.
- **Window.ts**: Updated JSDocs to correctly say "WebContentsView context" instead of "BrowserView context".
- **Tests**: Ran `bun test src/` and verified they pass correctly.
- **Lint**: Ran `bun run lint` and all output looks as expected with no new errors introduced.

---
*PR created automatically by Jules for task [3229005302786642581](https://jules.google.com/task/3229005302786642581) started by @arximus88*