### PR TITLE
chore: suppress debug logs in production for inputEnhancer.ts

### DIFF
--- a/src/main/preload/inputEnhancer.ts
+++ b/src/main/preload/inputEnhancer.ts
@@ -6,6 +6,8 @@
  * rendering engine to provide smoother interactions on Linux.
  */
 
+import { isDev } from "Utils/Common";
+
 // Track gesture state
 let isPinching = false;
 let lastPinchScale = 1.0;
@@ -105,7 +107,9 @@ function enhancePointerEvents(): void {
  * Initialize input enhancements
  */
 function initInputEnhancements(): void {
-  console.log("[Figma-Linux-Next] Initializing input enhancements for Wayland/Linux");
+  if (isDev) {
+    console.log("[Figma-Linux-Next] Initializing input enhancements for Wayland/Linux");
+  }
 
   // Intercept wheel events at capture phase for highest priority
   document.addEventListener("wheel", handleTrackpadGesture, {
@@ -121,7 +125,9 @@ function initInputEnhancements(): void {
     navigator.userAgent.includes("Wayland") || (window as any).DESKTOP_SESSION_TYPE === "wayland";
 
   if (isWayland) {
-    console.log("[Figma-Linux-Next] Wayland session detected - applying Wayland optimizations");
+    if (isDev) {
+      console.log("[Figma-Linux-Next] Wayland session detected - applying Wayland optimizations");
+    }
 
     // Set CSS for better rendering on Wayland
     document.documentElement.style.setProperty("will-change", "transform");
@@ -153,9 +159,11 @@ function initInputEnhancements(): void {
           });
 
           if (gl) {
-            console.log(
-              "[Figma-Linux-Next] WebGL2 context initialized with high-performance settings",
-            );
+            if (isDev) {
+              console.log(
+                "[Figma-Linux-Next] WebGL2 context initialized with high-performance settings",
+              );
+            }
           }
         }
       });


### PR DESCRIPTION
Wrapped console.log statements in src/main/preload/inputEnhancer.ts with `if (isDev)` checks to prevent noise in production environments. Used the `isDev` utility from `Utils/Common` for consistency across the codebase and added curly braces for better readability.