### PR TITLE
Remove unnessary plugin file restrictions

### DIFF
--- a/src/constants/other.ts
+++ b/src/constants/other.ts
@@ -26,18 +26,6 @@ export const REGEXP_APP_AUTH_GRANT = /^\/{0,2}app_auth\/[^/]+\/grant/;
 
 export const FIGMA_SESSION_COOKIE_NAME = "figma.session";
 
-export const FILE_WHITE_LIST = [".gitignore"];
-export const FILE_EXTENSION_WHITE_LIST = [
-  ".css",
-  ".html",
-  ".js",
-  ".json",
-  ".jsx",
-  ".md",
-  ".ts",
-  ".tsx",
-];
-
 export const NEW_FILE_TAB_TITLE = "New file";
 
 export const LINKS = {

--- a/src/main/ExtensionManager.ts
+++ b/src/main/ExtensionManager.ts
@@ -8,7 +8,7 @@ import * as Chokidar from "chokidar";
 import { dialogs } from "./Dialogs";
 import { storage } from "Storage";
 import { logger } from "./Logger";
-import { FILE_EXTENSION_WHITE_LIST, FILE_WHITE_LIST, MANIFEST_FILE_NAME } from "Const";
+import { MANIFEST_FILE_NAME } from "Const";
 import { ALLOW_CODE_FILES, ALLOW_EXT_FILES, ALLOW_UI_FILES } from "Utils/Common";
 import { access, mkPath } from "Utils/Main";
 
@@ -435,15 +435,6 @@ export default class ExtensionManager {
     }
     return id;
   }
-  private validateFileName(file: WebApi.WriteNewExtensionDirectoryToDiskFile) {
-    if (
-      !FILE_WHITE_LIST.includes(file.name) &&
-      (!FILE_EXTENSION_WHITE_LIST.includes(extname(file.name)) ||
-        !/^[\w\/]+(?:.\w+)*\.\w+/.test(file.name))
-    ) {
-      throw new Error(`Filename "${file.name}" not allowed`);
-    }
-  }
   private validateManidestFile(file: WebApi.WriteNewExtensionDirectoryToDiskFile) {
     if (typeof file.content !== "string") {
       throw new Error("Manifest must be a string");
@@ -463,17 +454,13 @@ export default class ExtensionManager {
     let manifestFile = null;
 
     for (const file of files) {
-      this.validateFileName(file);
-
       if (file.name === MANIFEST_FILE_NAME) {
         this.validateManidestFile(file);
 
         manifestFile = file;
       }
 
-      if (ALLOW_EXT_FILES.test(file.name)) {
-        observeFiles.add(file.name);
-      }
+      observeFiles.add(file.name);
     }
 
     if (!manifestFile) {


### PR DESCRIPTION
Old version had arbitrary file restrictions that don't match the native Figma version
I looked and couldn't find any reasons for this. 

The plugin I'm developing uses WASM, and since we can't use binary files, I make a txt file that contains the base64 text. 

super super niche use case, but better to avoid confusiion for other plugin developers using this in the future. 