### PR TITLE
chore(release): v0.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.13.6] - 2026-04-17
+
+### Added
+
+- **Tab cycling shortcuts** — `Ctrl+Tab` / `Ctrl+Shift+Tab` cycle through open tabs in insertion order, wrapping around ([#25](https://github.com/arximus88/figma-linux-next/issues/25))
+- **.desktop: "New Window" launcher action** — right-click the dock/taskbar icon to spawn a new window alongside existing ones; `--new-window` CLI flag added
+
+### Fixed
+
+- **Fonts: "Installed by you" list populated** — added snake-case `user_installed` field to the font payload that Figma's indexer classifies on (matches `neetly/figma-agent-linux` shape); local fonts now appear under the filter instead of the unclassified pool
+- **Prototype tab collapsed into editor tab** — `/proto/<key>` and `/file/<key>` now produce distinct dedup keys, so clicking "Open in presentation view" while an editor tab is open spawns a separate prototype tab instead of doing nothing (or vice versa when proto opens first)
+- **Dock actions ignored while app running** — `second-instance` handler now parses `--new-file=<type>` and `--new-window`; previously "New Design File" / "New FigJam" from the launcher only worked on cold start
+- **"Save last opened tabs" persistence** — `onWindowAllClosed` now flushes state before quit (previously only the menu "Quit" path saved), and `saveState` drops the tabs array when the toggle is off to avoid stale restores
+- **Renderer tsconfig TS6/TS5090 errors** — set `rootDir: ".."` and prefixed `DesktopAPI` path aliases with `./` after the TypeScript 6 upgrade tightened non-relative path handling
+
+---
+
 ## [0.13.5] - 2026-04-14
 
 ### Fixed

--- a/figma-linux-next.desktop
+++ b/figma-linux-next.desktop
@@ -11,10 +11,14 @@ Categories=Graphics;Design;VectorGraphics;
 MimeType=x-scheme-handler/figma;application/x-figma;
 Keywords=design;figma;ui;ux;interface;prototype;vector;
 StartupNotify=true
-Actions=NewFile;NewFigJam;
+Actions=NewWindow;NewFile;NewFigJam;
 
 # Native Wayland support hint
 X-GNOME-UsesNotifications=true
+
+[Desktop Action NewWindow]
+Name=New Window
+Exec=figma-linux-next --new-window
 
 [Desktop Action NewFile]
 Name=New Design File

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figma-linux-next",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "description": "Unofficial Electron-based browser wrapper for the Figma web app on Linux. Not affiliated with or endorsed by Figma, Inc.",
   "main": "dist/main/main.js",
   "repository": "https://github.com/arximus88/figma-linux-next.git",

--- a/src/main/App.ts
+++ b/src/main/App.ts
@@ -117,25 +117,35 @@ export default class App {
   };
 
   private secondInstance(event: Event, argv: string[]) {
-    let projectLink = "";
     logger.debug("second-instance, argv: ", argv);
 
-    const paramIndex = argv.findIndex((i) => isValidProjectLink(i));
     const hasAppAuthorization = argv.find((i) => isAppAuthLink(i));
-
-    logger.debug("second-instance, hasAppAuthorization: ", hasAppAuthorization);
-
     if (this.windowManager.tryHandleAppAuthRedeemUrl(hasAppAuthorization)) {
       return;
     }
 
-    if (paramIndex !== -1) {
-      projectLink = argv[paramIndex];
+    // Guard: Args() will process.exit() on -v/-h — drop those flags from a
+    // second invocation so the running app isn't killed by a help request.
+    const safeArgv = argv.filter((a) => a !== "-v" && a !== "--version" && a !== "-h" && a !== "--help");
+    const { figmaUrl, newWindow } = Args(safeArgv);
+
+    if (newWindow) {
+      this.windowManager.newWindow();
+      return;
     }
 
-    if (projectLink !== "") {
+    // Covers --new-file=<type> (figmaUrl is /file/new?editor_type=...) and
+    // direct figma:// or https://figma.com/... URLs passed on the command line.
+    if (figmaUrl) {
       this.windowManager.focusLastWindow();
-      this.windowManager.openUrl(projectLink);
+      this.windowManager.openUrl(figmaUrl);
+      return;
+    }
+
+    const projectLinkIdx = argv.findIndex((i) => isValidProjectLink(i));
+    if (projectLinkIdx !== -1) {
+      this.windowManager.focusLastWindow();
+      this.windowManager.openUrl(argv[projectLinkIdx]);
     }
   }
 

--- a/src/main/App.ts
+++ b/src/main/App.ts
@@ -265,7 +265,11 @@ export default class App {
   }
 
   private onWindowAllClosed() {
-    app.quit();
+    // Persist window/tab state before the app exits — X-button close goes
+    // through this path, not through the "Quit" menu, so without this the
+    // "save last opened tabs" setting would never actually persist anything.
+    this.windowManager.saveState();
+    storage.save().finally(() => app.quit());
   }
 
   private relaunchApp() {

--- a/src/main/Args.ts
+++ b/src/main/Args.ts
@@ -49,9 +49,11 @@ Options:
     -h, --help             Show this help message
     -v, --version          Show application version
     --new-file=TYPE        Create a new file (TYPE: design or figjam)
+    --new-window           Open a new application window
 
 Examples:
     figma-linux-next                                    # Launch application
+    figma-linux-next --new-window                       # Open a new window
     figma-linux-next --new-file=design                  # Create new design file
     figma-linux-next figma://file/abc123                # Open specific file
     figma-linux-next https://www.figma.com/file/xyz     # Open from URL

--- a/src/main/Args.ts
+++ b/src/main/Args.ts
@@ -4,11 +4,10 @@ const { version } = require("./../package.json");
 export interface AppArgs {
   figmaUrl: string;
   newFileType?: "design" | "figjam";
+  newWindow: boolean;
 }
 
-export default (): AppArgs => {
-  const argv = process.argv;
-
+export default (argv: string[] = process.argv): AppArgs => {
   let figmaUrl = "";
   let newFileType: "design" | "figjam" | undefined;
 
@@ -26,6 +25,8 @@ export default (): AppArgs => {
       figmaUrl = `https://www.figma.com/file/new?editor_type=${fileType}`;
     }
   }
+
+  const newWindow = argv.includes("--new-window");
 
   const urlIndex = argv.findIndex((i) => /^(figma:\/\/|https?:\/\/w{0,3}?\.?figma\.com)/.test(i));
   if (urlIndex !== -1) {
@@ -65,5 +66,6 @@ For more information, visit: https://github.com/arximus88/figma-linux-next
   return {
     figmaUrl,
     newFileType,
+    newWindow,
   };
 };

--- a/src/main/Fonts/index.ts
+++ b/src/main/Fonts/index.ts
@@ -81,9 +81,10 @@ export default class FontManager {
         if (!line.trim()) continue;
 
         const parts = line.split("\t");
-        if (parts.length < 7) continue;
+        if (parts.length < 8) continue;
 
-        const [filePath, family, style, postscript, weightStr, slantStr, widthStr] = parts;
+        const [filePath, family, style, postscript, weightStr, slantStr, widthStr, indexStr] =
+          parts;
         if (!filePath || !family) continue;
 
         // Mark variable-font "range" entries (e.g. weight="[0 215]") for Phase 3 enhancement.
@@ -98,6 +99,7 @@ export default class FontManager {
         const slant = parseInt(slantStr, 10);
         if (isNaN(fcWeight)) continue;
 
+        const fontIndex = indexStr ? parseInt(indexStr, 10) : undefined;
         const styleName = (style || "Regular").trim();
         const item: Fonts.IFontsFigmaItem = {
           postscript: postscript || `${family.replace(/ /g, "")}-${styleName.replace(/ /g, "")}`,
@@ -105,6 +107,7 @@ export default class FontManager {
           id: postscript || family,
           style: styleName,
           name: styleName,
+          index: isNaN(fontIndex!) ? undefined : fontIndex,
           weight: fcWeightToCSS(fcWeight),
           stretch: fcWidthToStretch(isNaN(fcWidth) ? 100 : fcWidth),
           italic: slant > 0,
@@ -188,9 +191,17 @@ export default class FontManager {
           for (const font of fonts) {
             if (font.variationAxes && Object.keys(font.variationAxes).length > 0) {
               for (const style of styles) {
-                // If it's a TTC, match the specific font face by postscript name
-                if (fonts.length > 1 && style.postscript !== font.postscriptName) continue;
-                this.enhanceWithVariableMetadata(style, font as Fonts.FontKitFont);
+                // Match by index if available (more reliable than PostScript for TTCs)
+                // Otherwise fall back to PostScript matching for non-TTC files
+                let matched = false;
+                if (style.index !== undefined && style.index < fonts.length) {
+                  this.enhanceWithVariableMetadata(style, fonts[style.index] as Fonts.FontKitFont);
+                  matched = true;
+                } else if (fonts.length === 1 || style.postscript === font.postscriptName) {
+                  this.enhanceWithVariableMetadata(style, font as Fonts.FontKitFont);
+                  matched = true;
+                }
+                if (matched && fonts.length > 1) break; // only match once per style
               }
             }
           }
@@ -255,7 +266,7 @@ export default class FontManager {
     return new Promise((resolve, reject) => {
       // %{family[0]} picks the first (English) family name from comma-separated list
       const format =
-        "%{file}\t%{family[0]}\t%{style[0]}\t%{postscriptname}\t%{weight}\t%{slant}\t%{width}\n";
+        "%{file}\t%{family[0]}\t%{style[0]}\t%{postscriptname}\t%{weight}\t%{slant}\t%{width}\t%{index}\n";
       const fc = spawn("fc-list", [`--format=${format}`]);
       let stdout = "";
       let stderr = "";

--- a/src/main/Fonts/index.ts
+++ b/src/main/Fonts/index.ts
@@ -111,6 +111,7 @@ export default class FontManager {
           weight: fcWeightToCSS(fcWeight),
           stretch: fcWidthToStretch(isNaN(fcWidth) ? 100 : fcWidth),
           italic: slant > 0,
+          user_installed: true,
         };
 
         if (!result[filePath]) result[filePath] = [];
@@ -157,6 +158,7 @@ export default class FontManager {
                   weight,
                   stretch: 5,
                   italic: isItalic,
+                  user_installed: true,
                 };
 
                 // Extract variable metadata immediately for custom fonts

--- a/src/main/Fonts/index.ts
+++ b/src/main/Fonts/index.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { readFile } from "fs/promises";
 import { statSync } from "fs";
+import * as fontkit from "fontkit"; // types provided by Fonts namespace
 import { logger } from "Main/Logger";
 
 // Fontconfig weight → CSS usWeightClass (piecewise linear, matches FcWeightToOpenType)
@@ -60,39 +61,50 @@ export default class FontManager {
     return readFile(path);
   };
 
+  /**
+   * Core logic for populating Figma-compatible font metadata.
+   * Figma's internal local font indexer expects a map of path -> style[].
+   * For variable fonts, it requires:
+   * 1. style.variationAxes: [{tag, name, min, max, default, value}]
+   *    Note: 'value' must be the specific coordinate for THIS named instance.
+   * 2. style.variationAxisValues: [{tag, value}]
+   * 3. style.useFontOpticalSize: boolean (true if 'opsz' axis exists)
+   */
   private async loadFonts(dirs: Array<string>) {
     const result: Fonts.IFonts = {};
+    const suspectedVariableFiles = new Set<string>();
 
-    // Primary: use fc-list to enumerate all fontconfig-registered fonts.
-    // This correctly handles variable fonts (each named instance as a separate entry),
-    // user fonts in ~/.local/share/fonts, and all system fonts.
+    // Phase 1: Enumerate all system fonts via fc-list (fast, covers 99% of fonts)
     try {
       const lines = await this.runFcList();
       for (const line of lines) {
         if (!line.trim()) continue;
 
-        // Format: file\tfamily\tstyle\tpostscript\tweight\tslant\twidth
         const parts = line.split("\t");
         if (parts.length < 7) continue;
 
         const [filePath, family, style, postscript, weightStr, slantStr, widthStr] = parts;
         if (!filePath || !family) continue;
 
-        // Skip variable-font "range" entries (e.g. weight="[0 215]") —
-        // fontconfig also emits one entry per named instance which covers these.
-        if (weightStr.includes("[") || widthStr.includes("[")) continue;
+        // Mark variable-font "range" entries (e.g. weight="[0 215]") for Phase 3 enhancement.
+        // We skip processing these rows as named instances but use them to identify variable fonts.
+        if (weightStr.includes("[") || widthStr.includes("[")) {
+          suspectedVariableFiles.add(filePath);
+          continue;
+        }
 
         const fcWeight = parseInt(weightStr, 10);
         const fcWidth = parseInt(widthStr, 10);
         const slant = parseInt(slantStr, 10);
         if (isNaN(fcWeight)) continue;
 
+        const styleName = (style || "Regular").trim();
         const item: Fonts.IFontsFigmaItem = {
-          postscript:
-            postscript || `${family.replace(/ /g, "")}-${(style || "Regular").replace(/ /g, "")}`,
+          postscript: postscript || `${family.replace(/ /g, "")}-${styleName.replace(/ /g, "")}`,
           family: family.trim(),
           id: postscript || family,
-          style: (style || "Regular").trim(),
+          style: styleName,
+          name: styleName,
           weight: fcWeightToCSS(fcWeight),
           stretch: fcWidthToStretch(isNaN(fcWidth) ? 100 : fcWidth),
           italic: slant > 0,
@@ -105,8 +117,7 @@ export default class FontManager {
       logger.warn("fc-list failed, falling back to fontkit:", error.message);
     }
 
-    // Supplement: scan any custom dirs whose fonts are not already covered by fontconfig.
-    // This handles fonts in non-standard locations that aren't registered with fontconfig.
+    // Phase 2: Supplement with custom directories not covered by fontconfig
     const fcFiles = new Set(Object.keys(result));
     for (const dir of dirs) {
       try {
@@ -115,14 +126,15 @@ export default class FontManager {
         if (newFiles.length === 0) continue;
 
         logger.info(`FontManager: scanning ${newFiles.length} non-fontconfig font(s) from ${dir}`);
-        const fontkit = await import("fontkit");
 
         await Promise.all(
           newFiles.map(async (filePath) => {
             try {
-              const fontOrCollection = await fontkit.open(filePath);
-              const fonts: any[] =
-                "fonts" in fontOrCollection ? fontOrCollection.fonts : [fontOrCollection];
+              const fontOrCollection = (await fontkit.open(filePath)) as Fonts.FontKitResult;
+              const isCollection = fontOrCollection.type === "TTC";
+              const fonts: Fonts.FontKitFont[] = isCollection
+                ? (fontOrCollection as Fonts.FontKitCollection).fonts
+                : [fontOrCollection as Fonts.FontKitFont];
               const items: Fonts.IFontsFigmaItem[] = [];
 
               for (const font of fonts) {
@@ -131,15 +143,22 @@ export default class FontManager {
                   (font.subfamilyName && font.subfamilyName.toLowerCase().includes("italic"));
                 let weight = 400;
                 if (font["OS/2"]?.usWeightClass) weight = font["OS/2"].usWeightClass;
-                items.push({
+                const styleName = font.subfamilyName || "Regular";
+
+                const item: Fonts.IFontsFigmaItem = {
                   postscript: font.postscriptName,
                   family: font.familyName,
                   id: font.postscriptName,
-                  style: font.subfamilyName || "Regular",
+                  style: styleName,
+                  name: styleName,
                   weight,
                   stretch: 5,
                   italic: isItalic,
-                });
+                };
+
+                // Extract variable metadata immediately for custom fonts
+                this.enhanceWithVariableMetadata(item, font as Fonts.FontKitFont);
+                items.push(item);
               }
 
               if (items.length > 0) result[filePath] = items;
@@ -149,15 +168,87 @@ export default class FontManager {
           }),
         );
       } catch {
-        // dir doesn't exist or unreadable — skip silently
+        // ignore unreadable dirs
       }
     }
+
+    // Phase 3: Enhancement - Extract metadata for variable fonts found via fc-list.
+    // We ONLY open files that fc-list flagged as variable, saving massive I/O.
+    await Promise.all(
+      Array.from(suspectedVariableFiles).map(async (filePath) => {
+        if (!result[filePath]) return;
+        try {
+          const styles = result[filePath];
+          const fontOrCollection = (await fontkit.open(filePath)) as Fonts.FontKitResult;
+          const isCollection = fontOrCollection.type === "TTC";
+          const fonts: Fonts.FontKitFont[] = isCollection
+            ? (fontOrCollection as Fonts.FontKitCollection).fonts
+            : [fontOrCollection as Fonts.FontKitFont];
+
+          for (const font of fonts) {
+            if (font.variationAxes && Object.keys(font.variationAxes).length > 0) {
+              for (const style of styles) {
+                // If it's a TTC, match the specific font face by postscript name
+                if (fonts.length > 1 && style.postscript !== font.postscriptName) continue;
+                this.enhanceWithVariableMetadata(style, font as Fonts.FontKitFont);
+              }
+            }
+          }
+        } catch (e) {
+          // ignore enhancement errors for individual files
+        }
+      }),
+    );
 
     this.fontList = result;
     const totalFaces = Object.values(result).reduce((s, arr) => s + arr.length, 0);
     logger.info(
       `FontManager: loaded ${totalFaces} font faces from ${Object.keys(result).length} files`,
     );
+  }
+
+  /**
+   * Helper to populate variationAxes and variationAxisValues from a fontkit object.
+   */
+  private enhanceWithVariableMetadata(item: Fonts.IFontsFigmaItem, font: Fonts.FontKitFont) {
+    if (!font.variationAxes || Object.keys(font.variationAxes).length === 0) return;
+
+    const variationAxesBase = Object.entries(font.variationAxes).map(([tag, axis]) => ({
+      tag,
+      name: axis.name,
+      min: axis.min,
+      max: axis.max,
+      default: axis.default,
+    }));
+
+    item.useFontOpticalSize = !!font.variationAxes["opsz"];
+
+    // 1. variationAxisValues: The raw coordinates for this named instance
+    if (font.namedVariations && font.namedVariations[item.style]) {
+      const variation = font.namedVariations[item.style];
+      item.variationAxisValues = Object.entries(variation).map(([tag, value]) => ({
+        tag,
+        value: value as number,
+      }));
+
+      // 2. variationAxes (with 'value'): Figma's UI needs the current coordinate
+      // to be present directly on the axis definition to show the sliders correctly.
+      item.variationAxes = variationAxesBase.map((axis) => ({
+        ...axis,
+        value: (variation as Record<string, number>)[axis.tag] ?? axis.default,
+      }));
+    } else {
+      // Fallback for variable fonts without matching named variations in the metadata
+      // We still provide the axis values (at defaults) so Figma enables the variable UI.
+      item.variationAxisValues = variationAxesBase.map((axis) => ({
+        tag: axis.tag,
+        value: axis.default,
+      }));
+      item.variationAxes = variationAxesBase.map((axis) => ({
+        ...axis,
+        value: axis.default,
+      }));
+    }
   }
 
   private runFcList(): Promise<string[]> {

--- a/src/main/Ui/MainTab.ts
+++ b/src/main/Ui/MainTab.ts
@@ -172,7 +172,7 @@ export default class MainTab {
   private windowOpenHandler(details: HandlerDetails) {
     const { url } = details;
 
-    if (/start_google_sso/.test(url)) {
+    if (url.startsWith("https://accounts.google.com/") && /start_google_sso/.test(url)) {
       return { action: "allow" as const };
     }
 
@@ -184,7 +184,7 @@ export default class MainTab {
 
     if (isFigmaRunUrl(url)) {
       app.emit("openUrlInNewTab", url);
-    } else {
+    } else if (url.startsWith("https://") || url.startsWith("http://")) {
       shell.openExternal(url);
     }
 

--- a/src/main/Ui/MenuManager.ts
+++ b/src/main/Ui/MenuManager.ts
@@ -24,6 +24,8 @@ export default class MenuManager {
       this.item("Reopen Closed Tab", "reopenClosedTab", "Ctrl+Shift+T"),
       // hidden items
       this.item("Fullscreen", "toggleWindowFullscreen", "F11", true, false),
+      this.item("Next Tab", "focusNextTab", "Ctrl+Tab", true, false),
+      this.item("Previous Tab", "focusPrevTab", "Ctrl+Shift+Tab", true, false),
     ];
 
     if (state?.recentClosedTabsMenuData?.length > 0) {

--- a/src/main/Ui/TabManager.ts
+++ b/src/main/Ui/TabManager.ts
@@ -132,6 +132,20 @@ export default class TabManager {
     this.tabs.forEach((t) => t.updateScale(scale));
   }
 
+  public getNextTabId(currentId: Types.TabIdType | undefined): number | undefined {
+    const ids = [...this.tabs.keys()];
+    if (ids.length === 0) return undefined;
+    const idx = typeof currentId === "number" ? ids.indexOf(currentId) : -1;
+    return ids[(idx + 1) % ids.length];
+  }
+
+  public getPrevTabId(currentId: Types.TabIdType | undefined): number | undefined {
+    const ids = [...this.tabs.keys()];
+    if (ids.length === 0) return undefined;
+    const idx = typeof currentId === "number" ? ids.indexOf(currentId) : 0;
+    return ids[(idx - 1 + ids.length) % ids.length];
+  }
+
   public getTabByIndex(index: number) {
     let i = 0;
     let foundTab: Types.Tab | undefined;

--- a/src/main/Ui/Window.ts
+++ b/src/main/Ui/Window.ts
@@ -659,6 +659,14 @@ export default class Window {
 
     app.emit("needUpdateMenu", this.id, tabId, { "close-tab": true });
   }
+  public focusNextTab() {
+    const nextId = this.tabManager.getNextTabId(this.tabManager.lastFocusedTab);
+    if (nextId !== undefined) this.setTabFocus(nextId);
+  }
+  public focusPrevTab() {
+    const prevId = this.tabManager.getPrevTabId(this.tabManager.lastFocusedTab);
+    if (prevId !== undefined) this.setTabFocus(prevId);
+  }
   public setTabTitle(event: IpcMainEvent, title: string) {
     // Ignore title updates from the warm tab (not yet promoted to active tab)
     if (this.warmTab && event.sender.id === this.warmTab.id) return;

--- a/src/main/Ui/Window.ts
+++ b/src/main/Ui/Window.ts
@@ -14,7 +14,7 @@ import {
   isFileBrowserUrl,
   normalizeUrl,
   parseURL,
-  getFileKeyFromUrl,
+  getTabDedupKey,
 } from "Utils/Common";
 import { panelUrlDev, panelUrlProd, toggleDetachedDevTools } from "Utils/Main";
 import Tab from "./Tab";
@@ -201,20 +201,21 @@ export default class Window {
     }
   }
 
-  /** Find an already-open tab for the same Figma file key (checks both stored and live URLs). */
-  private findTabByFileKey(url: string): Tab | undefined {
-    const key = getFileKeyFromUrl(url);
+  /** Find an already-open tab matching this URL's dedup key. Prototype and editor
+   *  URLs for the same file have different dedup keys and therefore coexist. */
+  private findTabForUrl(url: string): Tab | undefined {
+    const key = getTabDedupKey(url);
     if (!key) return undefined;
     for (const tab of this.tabManager.getAll().values()) {
-      const storedKey = tab.url ? getFileKeyFromUrl(tab.url) : null;
-      const liveKey = getFileKeyFromUrl(tab.getUrl());
+      const storedKey = tab.url ? getTabDedupKey(tab.url) : null;
+      const liveKey = getTabDedupKey(tab.getUrl());
       if (storedKey === key || liveKey === key) return tab;
     }
     return undefined;
   }
 
   public openUrlFromCommunity(url: string) {
-    const existing = this.findTabByFileKey(url);
+    const existing = this.findTabForUrl(url);
     if (existing) {
       this.setTabFocus(existing.id);
       return;
@@ -235,7 +236,7 @@ export default class Window {
       this.setFocusToMainTab();
     } else if (/figma:\/\//.test(url)) {
       const httpUrl = url.replace(/figma:\//, HOMEPAGE);
-      const existing = this.findTabByFileKey(httpUrl);
+      const existing = this.findTabForUrl(httpUrl);
       if (existing) {
         this.setTabFocus(existing.id);
         return;
@@ -243,7 +244,7 @@ export default class Window {
       const tab = this.addTab(httpUrl);
       if (tab) this.setTabFocus(tab.id);
     } else if (/https?:\/\//.test(url)) {
-      const existing = this.findTabByFileKey(url);
+      const existing = this.findTabForUrl(url);
       if (existing) {
         this.setTabFocus(existing.id);
         return;
@@ -697,7 +698,7 @@ export default class Window {
       return;
     }
 
-    const existing = this.findTabByFileKey(url);
+    const existing = this.findTabForUrl(url);
     if (existing) {
       this.closeNewFileTab();
       this.setTabFocus(existing.id);

--- a/src/main/Ui/WindowManager.ts
+++ b/src/main/Ui/WindowManager.ts
@@ -138,9 +138,12 @@ export default class WindowManager {
 
   public saveState() {
     storage.settings.app.windowsState = {};
+    const keepTabs = storage.settings.app.saveLastOpenedTabs;
 
     for (const [_, window] of this.windows) {
       const { windowId, ...state } = window.getState();
+
+      if (!keepTabs) state.tabs = [];
 
       storage.settings.app.windowsState[windowId] = state;
     }

--- a/src/main/Ui/WindowManager.ts
+++ b/src/main/Ui/WindowManager.ts
@@ -316,6 +316,14 @@ export default class WindowManager {
 
     this.handleCloseTab(window, tabId);
   }
+  private focusNextTabFromMenu(windowId: number) {
+    const window = this.windows.get(windowId || this.lastFocusedwindowId);
+    window?.focusNextTab();
+  }
+  private focusPrevTabFromMenu(windowId: number) {
+    const window = this.windows.get(windowId || this.lastFocusedwindowId);
+    window?.focusPrevTab();
+  }
   private closeCurrentTabFromMenu(windowId: number) {
     const window = this.windows.get(windowId || this.lastFocusedwindowId);
     const tabId = window.getLatestFocusedTabId();
@@ -631,6 +639,8 @@ export default class WindowManager {
     app.on("newWindow", this.newWindowFromMenu.bind(this));
     app.on("reloadTab", this.reloadTabFromMenu.bind(this));
     app.on("closeTab", this.closeTabFromMenu.bind(this));
+    app.on("focusNextTab", this.focusNextTabFromMenu.bind(this));
+    app.on("focusPrevTab", this.focusPrevTabFromMenu.bind(this));
     app.on("closeCurrentTab", this.closeCurrentTabFromMenu.bind(this));
     app.on("reopenClosedTab", this.reopenClosedTabFromMenu.bind(this));
     app.on("closeCurrentWindow", this.closeCurrentWindowFromMenu.bind(this));

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "figma-linux-next",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "description": "Optimized Figma desktop application for Linux with native Wayland support, GPU acceleration, and system integration.",
   "main": "main/main.js",
   "repository": "https://github.com/arximus88/figma-linux-next.git",

--- a/src/renderer/tsconfig.json
+++ b/src/renderer/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist",
+    "rootDir": "..",
     "useUnknownInCatchVariables": false,
     "allowArbitraryExtensions": true,
     "noImplicitAny": true,
@@ -40,8 +41,8 @@
       "Common/*": ["../renderer/Common/*"],
       "Containers": ["../renderer/Common/Containers"],
       "Containers/*": ["../renderer/Common/Containers/*"],
-      "DesktopAPI": ["DesktopAPI"],
-      "DesktopAPI/*": ["DesktopAPI/*"],
+      "DesktopAPI": ["./DesktopAPI"],
+      "DesktopAPI/*": ["./DesktopAPI/*"],
       "Const": ["../constants"],
       "Utils": ["../utils"],
       "Utils/*": ["../utils/*"],

--- a/src/types/Main/fonts.d.ts
+++ b/src/types/Main/fonts.d.ts
@@ -1,16 +1,66 @@
 declare namespace Fonts {
+  interface FontKitFontBase {
+    type: string;
+    postscriptName: string;
+    familyName: string;
+    subfamilyName: string;
+    italicAngle: number;
+    variationAxes?: Record<
+      string,
+      {
+        name: string;
+        min: number;
+        default: number;
+        max: number;
+      }
+    >;
+    namedVariations?: Record<string, Record<string, number>>;
+    "OS/2"?: {
+      usWeightClass: number;
+    };
+  }
+
+  type FontKitFont = FontKitFontBase & {
+    fonts?: undefined;
+  };
+
+  type FontKitCollection = FontKitFontBase & {
+    type: "TTC";
+    fonts: FontKitFont[];
+  };
+
+  type FontKitResult = FontKitFont | FontKitCollection;
+
+  interface IndexFontVariationAxis {
+    tag: string;
+    name: string;
+    min: number;
+    max: number;
+    default: number;
+    value?: number;
+  }
+
+  interface IndexFontVariationAxisValue {
+    tag: string;
+    value: number;
+  }
+
   interface IFontsFigmaItem {
     postscript: string;
     family: string;
     id: string;
     style: string;
+    name?: string;
     weight: number;
     stretch: number;
     italic: boolean;
+    variationAxes?: IndexFontVariationAxis[];
+    variationAxisValues?: IndexFontVariationAxisValue[];
+    useFontOpticalSize?: boolean;
   }
 
   interface IFonts {
-    [path: string]: Array<IFontsFigmaItem>;
+    [path: string]: IFontsFigmaItem[];
   }
 
   interface NameTableResult {

--- a/src/types/Main/fonts.d.ts
+++ b/src/types/Main/fonts.d.ts
@@ -58,6 +58,7 @@ declare namespace Fonts {
     variationAxes?: IndexFontVariationAxis[];
     variationAxisValues?: IndexFontVariationAxisValue[];
     useFontOpticalSize?: boolean;
+    user_installed?: boolean;
   }
 
   interface IFonts {

--- a/src/types/Main/fonts.d.ts
+++ b/src/types/Main/fonts.d.ts
@@ -51,6 +51,7 @@ declare namespace Fonts {
     id: string;
     style: string;
     name?: string;
+    index?: number;
     weight: number;
     stretch: number;
     italic: boolean;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -17,6 +17,8 @@ declare namespace Electron {
     on(event: "reloadTab", listener: (tabId: number) => void): this;
     on(event: "closeTab", listener: (windowId: number, tabId: number) => void): this;
     on(event: "closeCurrentTab", listener: (windowId: number) => void): this;
+    on(event: "focusNextTab", listener: (windowId: number) => void): this;
+    on(event: "focusPrevTab", listener: (windowId: number) => void): this;
     on(event: "reopenClosedTab", listener: (windowId: number) => void): this;
     on(event: "closeCurrentWindow", listener: (windowId: number) => void): this;
     on(event: "toggleWindowFullscreen", listener: (windowId: number) => void): this;

--- a/src/utils/Common/url.ts
+++ b/src/utils/Common/url.ts
@@ -110,3 +110,17 @@ export const getFileKeyFromUrl = (url: string): string | null => {
 
   return null;
 };
+
+/** Dedup key for "is this URL already open in a tab?" — separates the prototype
+ *  viewer (/proto/<key>) from the editor (/file|design|board/<key>) so both
+ *  can coexist as distinct tabs for the same document. */
+export const getTabDedupKey = (url: string): string | null => {
+  const parsed = parseURL(url);
+  if (!parsed) return null;
+
+  const match = parsed.pathname.match(/^\/(file|design|board|proto)\/([a-zA-Z0-9]+)/);
+  if (!match) return null;
+
+  const [, type, key] = match;
+  return type === "proto" ? `proto:${key}` : `doc:${key}`;
+};

--- a/tests/unit/utils/Common/url.test.ts
+++ b/tests/unit/utils/Common/url.test.ts
@@ -1,5 +1,11 @@
 import { describe, test, expect } from "bun:test";
-import { normalizeUrl, getFileKeyFromUrl, isFigmaRunUrl, isFileBrowserUrl } from "Utils/Common/url";
+import {
+  normalizeUrl,
+  getFileKeyFromUrl,
+  getTabDedupKey,
+  isFigmaRunUrl,
+  isFileBrowserUrl,
+} from "Utils/Common/url";
 import { HOMEPAGE } from "Const";
 
 describe("normalizeUrl", () => {
@@ -60,6 +66,39 @@ describe("getFileKeyFromUrl", () => {
   test("returns null for invalid URL", () => {
     expect(getFileKeyFromUrl("not-a-url")).toBeNull();
     expect(getFileKeyFromUrl("")).toBeNull();
+  });
+});
+
+describe("getTabDedupKey", () => {
+  test("returns 'doc:<key>' for file/design/board URLs", () => {
+    expect(getTabDedupKey("https://www.figma.com/file/ABC123/x")).toBe("doc:ABC123");
+    expect(getTabDedupKey("https://www.figma.com/design/ABC123/x")).toBe("doc:ABC123");
+    expect(getTabDedupKey("https://www.figma.com/board/ABC123/x")).toBe("doc:ABC123");
+  });
+
+  test("returns 'proto:<key>' for prototype URLs", () => {
+    expect(getTabDedupKey("https://www.figma.com/proto/ABC123/x")).toBe("proto:ABC123");
+    expect(getTabDedupKey("https://www.figma.com/proto/ABC123?node-id=1-2")).toBe("proto:ABC123");
+  });
+
+  test("file and proto URLs for the same key produce different dedup keys", () => {
+    expect(getTabDedupKey("https://www.figma.com/file/SAME/a")).not.toBe(
+      getTabDedupKey("https://www.figma.com/proto/SAME/b"),
+    );
+  });
+
+  test("file, design and board with the same key dedupe together", () => {
+    const a = getTabDedupKey("https://www.figma.com/file/SAME/a");
+    const b = getTabDedupKey("https://www.figma.com/design/SAME/b");
+    const c = getTabDedupKey("https://www.figma.com/board/SAME/c");
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+  });
+
+  test("returns null for non-figma and malformed URLs", () => {
+    expect(getTabDedupKey("https://www.figma.com/community/file/ABC")).toBeNull();
+    expect(getTabDedupKey("not-a-url")).toBeNull();
+    expect(getTabDedupKey("")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Release v0.13.6 — tab UX improvements, variable fonts, launcher fixes.

### Added
- Ctrl+Tab / Ctrl+Shift+Tab to cycle between open tabs
- "New Window" action in .desktop launcher menu

### Fixed
- Local fonts now appear under "Installed by you" in Figma's font picker (snake-case `user_installed` field)
- "Open in presentation view" opens a separate prototype tab alongside the file editor (was collapsing into a single tab)
- Dock actions (New Design File / New FigJam / New Window) now work while the app is already running
- "Save last opened tabs" actually persists and restores on relaunch
- Variable fonts correctly expose variationAxes / named instances (via PR #27 by @Arecsu)
- Renderer tsconfig TS6/TS5090 errors after TypeScript 6 upgrade

Closes #25
Closes #26

## Test plan

- [x] Unit tests pass (112/112)
- [x] Typecheck + lint clean
- [x] E2E tests pass (20/20)
- [x] CI green on this PR