### PR TITLE
fix(fonts): only mark fonts in user dirs as user_installed

### DIFF
--- a/src/main/Fonts/index.ts
+++ b/src/main/Fonts/index.ts
@@ -70,6 +70,18 @@ export default class FontManager {
    * 2. style.variationAxisValues: [{tag, value}]
    * 3. style.useFontOpticalSize: boolean (true if 'opsz' axis exists)
    */
+  /** True for fonts in the standard Linux user font directories. Used to flag
+   *  entries as `user_installed` so they appear under Figma's "Installed by you"
+   *  filter — system fonts in /usr/share/fonts stay out of that bucket. */
+  private isUserInstalledPath(filePath: string): boolean {
+    const home = process.env.HOME;
+    if (!home) return false;
+    return (
+      filePath.startsWith(`${home}/.local/share/fonts/`) ||
+      filePath.startsWith(`${home}/.fonts/`)
+    );
+  }
+
   private async loadFonts(dirs: Array<string>) {
     const result: Fonts.IFonts = {};
     const suspectedVariableFiles = new Set<string>();
@@ -111,7 +123,7 @@ export default class FontManager {
           weight: fcWeightToCSS(fcWeight),
           stretch: fcWidthToStretch(isNaN(fcWidth) ? 100 : fcWidth),
           italic: slant > 0,
-          user_installed: true,
+          user_installed: this.isUserInstalledPath(filePath),
         };
 
         if (!result[filePath]) result[filePath] = [];


### PR DESCRIPTION
Follow-up to #28 — shipping with v0.13.6.

The previous change set `user_installed: true` on every fc-list entry, which included `/usr/share/fonts`, polluting Figma's "Installed by you" filter with system fonts. This gates the flag on the standard Linux user font directories (`$HOME/.local/share/fonts`, `$HOME/.fonts`) so only actually user-installed fonts surface under that filter.

Custom dirs from `settings.app.fontDirs` keep `user_installed: true` since the user opts into them explicitly via the Settings UI.

## Test plan
- [x] Unit tests pass (112/112)
- [x] Typecheck + lint clean
- [x] Manual: `/usr/share/fonts/*` no longer appears in "Installed by you"; `~/.local/share/fonts/Inter Variable` still does