### PR TITLE
docs(license): align license metadata to GPL-2.0-only (+ sync dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,4 @@ bun run pack     # build all packages
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+GPL-2.0-only — see [LICENSE](LICENSE).

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/arximus88/figma-linux-next.git",
   "homepage": "https://github.com/arximus88/figma-linux-next",
   "author": "Figma Linux Community",
-  "license": "MIT",
+  "license": "GPL-2.0-only",
   "scripts": {
     "start": "bun run build && bun run run",
     "dev": "cross-env NODE_ENV=dev vite",

--- a/src/package.json
+++ b/src/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/arximus88/figma-linux-next.git",
   "homepage": "https://github.com/arximus88/figma-linux-next",
   "author": "Figma Linux Community",
-  "license": "MIT",
+  "license": "GPL-2.0-only",
   "dependencies": {
     "adm-zip": "^0.5.17",
     "chokidar": "^5.0.0",


### PR DESCRIPTION
Not a release — no version bump, no tag will be pushed. v0.13.8 is already out.

Brings `staging` into `dev` (which had fallen behind). The only new change is the license metadata correction; the rest are commits already shipped in v0.13.8 that simply weren't merged into `dev` yet.

## New in this PR
- **chore(license):** correct license metadata to **GPL-2.0-only** in `package.json`, `src/package.json`, and `README.md`. `LICENSE` is GPL-2.0 (inherited from upstream figma-linux); the previous `MIT` declarations were misleading for forks. `LICENSE` itself is unchanged.

## Already-shipped commits being synced to dev
- fix(window): invalidate warm tab when active user changes; skeleton on warm-tab promotion
- fix(auth): redeem relative-URL guard + webPort handler type; multi-user add-account + first-login regression
- chore(release): 0.13.8 bump + CHANGELOG (already tagged/released from staging)