### PR TITLE
fix(ci): resolve the repo root when sync_flatpak_release.py runs from /tmp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -385,6 +385,8 @@ jobs:
           token: ${{ secrets.RELEASE_PAT }}
 
       - name: Pin the manifest to this release
+        env:
+          FIGMA_REPO_ROOT: ${{ github.workspace }}
         run: |
           VERSION=${GITHUB_REF_NAME#v}
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
@@ -402,6 +404,8 @@ jobs:
           git push origin dev
 
       - name: Mirror to staging
+        env:
+          FIGMA_REPO_ROOT: ${{ github.workspace }}
         run: |
           git fetch origin staging:staging
           git checkout staging

--- a/flake.nix
+++ b/flake.nix
@@ -21,10 +21,10 @@
       # the previous release — that window is the build itself, not a release
       # cycle: CI writes the new pair to dev as soon as the binaries exist.
       release = {
-        version = "0.16.0";
+        version = "0.17.0";
         hashes = {
-          x86_64-linux  = "sha256-lVdSCIKt75j6fTXuq6+oS8p+nOXZoQoykVFVzWb61tw=";
-          aarch64-linux = "sha256-FXVSTYUcwpIILVRkGI+0Lp03H9kceZZqAn+CPnVsXQs=";
+          x86_64-linux  = "sha256-rLTruBI+1+mZZJFlaEixMxrqgNW3/4ZwMQfIU7Deofg=";
+          aarch64-linux = "sha256-NyrE3fI7GnjtXT0+zCXd2gbOh3VzqrKDh6srJPanTVM=";
         };
       };
 

--- a/flatpak/app.borys.FigmaLinuxNext.yml
+++ b/flatpak/app.borys.FigmaLinuxNext.yml
@@ -125,6 +125,7 @@ modules:
       - type: git
         url: https://github.com/arximus88/figma-linux-next.git
         tag: v0.17.0
+        commit: bb4eb2f2e50be0efe0f24d4e096a45da12f4baf8
       - generated-sources.json
       # These four overwrite what the git checkout brought in. Packaging metadata
       # is edited here and takes effect on the next build; read from the tag it

--- a/scripts/sync_flatpak_release.py
+++ b/scripts/sync_flatpak_release.py
@@ -26,13 +26,16 @@ in flatpak/package-lock.json, and no source may point outside npm/Electron.
 import base64
 import binascii
 import json
+import os
 import re
 import sys
 from datetime import date
 from pathlib import Path
 from urllib.parse import urlparse
 
-ROOT = Path(__file__).resolve().parent.parent
+# The release workflow copies this script outside the worktree so it survives a
+# branch switch; FIGMA_REPO_ROOT tells it where the tree actually lives.
+ROOT = Path(os.environ.get("FIGMA_REPO_ROOT") or Path(__file__).resolve().parent.parent)
 FLATPAK_DIR = ROOT / "flatpak"
 MANIFEST = FLATPAK_DIR / "app.borys.FigmaLinuxNext.yml"
 METAINFO = FLATPAK_DIR / "app.borys.FigmaLinuxNext.metainfo.xml"


### PR DESCRIPTION
The `flatpak-pin` job of the v0.17.0 release failed with
`missing flatpak/app.borys.FigmaLinuxNext.yml`.

`sync_flatpak_release.py` derived the repo root from `__file__`. The job copies
the script to `/tmp` so it survives the `git checkout staging` in the mirror
step, which made the root resolve to `/`.

- `FIGMA_REPO_ROOT` now names the tree, with the old `__file__` logic as the
  fallback (`--check` in `ci.yml` is unaffected).
- Both `flatpak-pin` steps set it to `${{ github.workspace }}`.
- `flatpak/app.borys.FigmaLinuxNext.yml` gets the `commit:` pin the failed job
  never wrote — without it a Flatpak build from `dev` follows a movable tag.

No version bump: only workflow code changed.